### PR TITLE
Recognize all legal zettel ids

### DIFF
--- a/plugin/neuron.vim
+++ b/plugin/neuron.vim
@@ -26,7 +26,7 @@ let g:style_virtual_title = get(g:, 'style_virtual_title', 'Comment')
 " }}}
 " Variables {{{1
 
-let g:re_neuron_link = '<\([0-9a-z]\{8}\)>'
+let g:re_neuron_link = '<\([0-9a-zA-Z_-]\+\)>'
 
 " }}}
 " Functions {{{1


### PR DESCRIPTION
Neuron actually supports `[0-9a-zA-Z-_]+` as ids, see [here](https://github.com/srid/neuron/blob/4719f1e396b6585605d8bca99b3fe279107da9bc/neuron/src/lib/Neuron/Zettelkasten/ID.hs#L127).