### PR TITLE
fix: crash in is_zettelid_valid

### DIFF
--- a/autoload/util.vim
+++ b/autoload/util.vim
@@ -33,6 +33,9 @@ func! util#is_zettelid_valid(zettelid)
 	if empty(a:zettelid)
 		return 0
 	end
+	if !exists('g:cache_zettels') || empty('g:cache_zettels')
+		call neuron#refresh_cache()
+	endif
 	if index(keys(g:cache_zettels), util#deform_zettelid(a:zettelid)) >= 0
 		return 1
 	else


### PR DESCRIPTION
```
Error detected while processing function <SNR>13_set_filetype[5]..<SNR>13_add_virtual_titles[13]..util#is_zettelid_valid:
line    4:
E121: Undefined variable: g:cache_zettels
E116: Invalid arguments for function keys
E116: Invalid arguments for function index
E15: Invalid expression: index(keys(g:cache_zettels), util#deform_zettelid(a:zettelid)) >= 0
```