### PR TITLE
docs: update default mappings listed in doc/

### DIFF
--- a/doc/neuron.vim.txt
+++ b/doc/neuron.vim.txt
@@ -26,12 +26,14 @@ g:fzf_options           All fzf commands are uses these options. For example
 MAPPINGS                                        *neuron.vim-mappings*
 
 >
-             nm <m-z>           :call ZettelSearch()<cr>
-             nm <LocalLeader>zn :call ZettelNew()<cr>
-             nm <LocalLeader>zi :call ZettelSearchInsert()<cr>
-             nm <LocalLeader>zl :call ZettelLastInsert()<cr>
-             nm <LocalLeader>zo :call ZettelOpenUnderCursor()<cr>
-             nm <LocalLeader>zu :call ZettelOpenLast()<cr>
+             nm gzn <Plug>EditZettelNew
+             nm gzb <Plug>NeuronRibStart
+             nm gzu <Plug>EditZettelLast
+             nm gzl <Plug>InsertZettelLast
+             nm gzz <Plug>EditZettelSelect
+             nm gzi <Plug>InsertZettelSelect
+             nm gzr <Plug>NeuronRefreshCache
+             nm gzo <Plug>EditZettelUnderCursor
 
 ABOUT                                           *neuron.vim-about*
 


### PR DESCRIPTION
As I was reading through the docs I noticed the key mappings listed didn't actually match the mappings made by the plugin.

This just updates the block under `MAPPINGS` to match what's in `plugin/nueron.vim`