### PR TITLE
updated zettel_new to respect defined zkdir

### DIFF
--- a/autoload/neuron.vim
+++ b/autoload/neuron.vim
@@ -57,7 +57,7 @@ func! neuron#insert_zettel_last()
 endf
 
 func! neuron#edit_zettel_new() " relying on https://github.com/srid/neuron
-	exec 'e '.system('neuron new "PLACEHOLDER"')
+	exec 'e '.system('neuron -d '.shellescape(g:zkdir).' new "PLACEHOLDER"')
 		\ .' | call search("PLACEHOLDER") | norm"_D'
 	startinsert!
 	call neuron#refresh_cache()


### PR DESCRIPTION
As it stands EditZettelNew does not respect a defined zkdir; modified the function to pull in zkdir as refresh_cache already does. 

Edit: Updated to target dev