### PR TITLE
Allow <yyyy-mm-dd> zettels in edit_zettels_under_cursor

### DIFF
--- a/autoload/neuron.vim
+++ b/autoload/neuron.vim
@@ -52,7 +52,7 @@ func! neuron#edit_zettel_under_cursor()
 	if util#is_zettelid_valid(l:zettel_id)
 		call neuron#edit_zettel(l:zettel_id)
 	else
-	    let l:zettel_id = trim(expand('<cWORD>'), "<>")
+		let l:zettel_id = trim(expand('<cWORD>'), "<>")
 		if util#is_zettelid_valid(l:zettel_id)
 			call neuron#edit_zettel(l:zettel_id)
 		else

--- a/autoload/neuron.vim
+++ b/autoload/neuron.vim
@@ -52,7 +52,12 @@ func! neuron#edit_zettel_under_cursor()
 	if util#is_zettelid_valid(l:zettel_id)
 		call neuron#edit_zettel(l:zettel_id)
 	else
-		call util#handlerr('E3')
+	    let l:zettel_id = trim(expand('<cWORD>'), "<>")
+		if util#is_zettelid_valid(l:zettel_id)
+			call neuron#edit_zettel(l:zettel_id)
+		else
+			call util#handlerr('E3')
+		endif
 	endif
 endf
 


### PR DESCRIPTION
My old notes system has a lot of date based zettels (because I keep a daily log of stuff).
<2020-07-31> currently does not work with 'gzo' - it tries to open a zettel '31' for example.

This keeps the old behaviour (preferentially open a zettel 31), but adds a fallback
if no zettel is found to use the full cWORD (minus the <>).