### PR TITLE
Better g:zkdir handling

### DIFF
--- a/autoload/neuron.vim
+++ b/autoload/neuron.vim
@@ -58,7 +58,7 @@ endf
 
 " FIXME ihsanturk#31: vip
 func! neuron#edit_zettel_new() " relying on https://github.com/srid/neuron
-	exec 'e '.system('neuron -d '.shellescape(g:zkdir).' new "PLACEHOLDER"')
+	exec 'e '.s:run_neuron('new "PLACEHOLDER"')
 		\ .' | call search("PLACEHOLDER") | norm"_D'
 	startinsert!
 	call neuron#refresh_cache()
@@ -89,8 +89,7 @@ endf
 
 " TODO: Remove jq dependency find vimscript native solution.
 func! neuron#refresh_cache()
-	let l:neuron_output = s:run_neuron(
-		\ "-d ".shellescape(g:zkdir)." query --uri 'z:zettels'")
+	let l:neuron_output = s:run_neuron("query --uri 'z:zettels'")
 	let jq_output =
 		\ s:run_jq("'reduce .result[] as $i ({}; .[$i.zettelID]=$i)'",
 			\ l:neuron_output)
@@ -107,7 +106,7 @@ func! s:run_neuron(cmd)
 			call util#handlerr('E1')
 		endif
 	endtry
-	let l:cmdout = system(g:path_neuron.' '.a:cmd)
+	let l:cmdout = system(g:path_neuron.' -d '.shellescape(g:zkdir).' '.a:cmd)
 	if v:shell_error != 0
 		call s:warn(l:cmdout)
 		call util#handlerr('E5')

--- a/autoload/rpc.vim
+++ b/autoload/rpc.vim
@@ -7,7 +7,7 @@ func! rpc#start_server()
 		\ 'on_exit': function('s:on_exit'),
 	\}
 	if g:neuron_rib_job == -1
-		let g:neuron_rib_job = jobstart(['neuron', 'rib', '-wS'], options)
+		let g:neuron_rib_job = jobstart(['neuron', '-d', g:zkdir, 'rib', '-wS'], options)
 		echom 'Neuron rib server started.'
 	end
 	echom 'Opening http://127.0.0.1:8080/...'

--- a/ftdetect/neuron.vim
+++ b/ftdetect/neuron.vim
@@ -1,5 +1,8 @@
 let g:zextension = get(g:, 'zextension', '.md')
 let g:zkdir = get(g:, 'zkdir', $HOME.'/zettelkasten/')
+if g:zkdir !~ "/$"
+	let g:zkdir = g:zkdir . '/'
+endif
 
 if exists('b:did_ftdetect') | finish | endif
 aug neuron


### PR DESCRIPTION
The first commit adds the `-d g:zkdir` to the `s:run_neuron` function, instead of having to pass it to every call. It also adds the parameter to the `rib` call where it was missing. 

The second commit simply appends `/` to `g:zkdir` if it isn't there. If `zkdir` is missing the last `/`, opening a zettel with `gzz` will try to open a file composed of the `zkdir` + the filename of the zettel, without `/` in between. I don't know if there is a better way to do this in vim.